### PR TITLE
PR: URL 단축 서비스의 데이터베이스 연동 및 개선

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     runtimeOnly("org.postgresql:postgresql")
     
+    // Validation
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
     testCompileOnly("org.projectlombok:lombok:1.18.36")
     testAnnotationProcessor("org.projectlombok:lombok")
     
+    // Database
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    runtimeOnly("org.postgresql:postgresql")
+    
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
+    
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok:1.18.36")
+    testCompileOnly("org.projectlombok:lombok:1.18.36")
+    testAnnotationProcessor("org.projectlombok:lombok")
+    
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/main/java/community/whatever/onembackendjava/UrlShortenController.java
+++ b/src/main/java/community/whatever/onembackendjava/UrlShortenController.java
@@ -4,6 +4,7 @@ import community.whatever.onembackendjava.dto.CreateShortenUrlRequest;
 import community.whatever.onembackendjava.dto.CreateShortenUrlResponse;
 import community.whatever.onembackendjava.dto.SearchShortenUrlRequest;
 import community.whatever.onembackendjava.dto.SearchShortenUrlResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,7 +22,7 @@ public class UrlShortenController {
     }
 
     @PostMapping("/shorten-url/create")
-    public CreateShortenUrlResponse shortenUrlCreate(@RequestBody CreateShortenUrlRequest request) {
+    public CreateShortenUrlResponse shortenUrlCreate(@Valid @RequestBody CreateShortenUrlRequest request) {
         return urlShortenService.createShortenUrl(request);
     }
 }

--- a/src/main/java/community/whatever/onembackendjava/UrlShortenController.java
+++ b/src/main/java/community/whatever/onembackendjava/UrlShortenController.java
@@ -4,31 +4,24 @@ import community.whatever.onembackendjava.dto.CreateShortenUrlRequest;
 import community.whatever.onembackendjava.dto.CreateShortenUrlResponse;
 import community.whatever.onembackendjava.dto.SearchShortenUrlRequest;
 import community.whatever.onembackendjava.dto.SearchShortenUrlResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-
 @RestController
+@RequiredArgsConstructor
 public class UrlShortenController {
 
-    private final Map<String, String> shortenUrls = new HashMap<>();
+    private final UrlShortenService urlShortenService;
 
     @PostMapping("/shorten-url/search")
-    public SearchShortenUrlResponse shortenUrlSearch(@RequestBody SearchShortenUrlRequest searchShortenUrlRequest) {
-        if (!shortenUrls.containsKey(searchShortenUrlRequest.key())) {
-            throw new IllegalArgumentException("Invalid key");
-        }
-        return new SearchShortenUrlResponse(shortenUrls.get(searchShortenUrlRequest.key()));
+    public SearchShortenUrlResponse shortenUrlSearch(@RequestBody SearchShortenUrlRequest request) {
+        return urlShortenService.searchShortenUrl(request);
     }
 
     @PostMapping("/shorten-url/create")
-    public CreateShortenUrlResponse shortenUrlCreate(@RequestBody CreateShortenUrlRequest createShortenUrlRequest) {
-        String randomKey = String.valueOf(new Random().nextInt(10000));
-        shortenUrls.put(randomKey, createShortenUrlRequest.originUrl());
-        return new CreateShortenUrlResponse(randomKey);
+    public CreateShortenUrlResponse shortenUrlCreate(@RequestBody CreateShortenUrlRequest request) {
+        return urlShortenService.createShortenUrl(request);
     }
 }

--- a/src/main/java/community/whatever/onembackendjava/UrlShortenService.java
+++ b/src/main/java/community/whatever/onembackendjava/UrlShortenService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Random;
 
 @Service
@@ -24,6 +25,7 @@ public class UrlShortenService {
         ShortenUrl shortenUrl = shortenUrlRepository.findByShortenKey(request.key())
                 .orElseThrow(() -> new IllegalArgumentException("Invalid key"));
         
+        shortenUrl.setLastAccessedAt(LocalDateTime.now());
         shortenUrlRepository.save(shortenUrl);
         
         return new SearchShortenUrlResponse(shortenUrl.getOriginalUrl());

--- a/src/main/java/community/whatever/onembackendjava/UrlShortenService.java
+++ b/src/main/java/community/whatever/onembackendjava/UrlShortenService.java
@@ -4,26 +4,42 @@ import community.whatever.onembackendjava.dto.CreateShortenUrlRequest;
 import community.whatever.onembackendjava.dto.CreateShortenUrlResponse;
 import community.whatever.onembackendjava.dto.SearchShortenUrlRequest;
 import community.whatever.onembackendjava.dto.SearchShortenUrlResponse;
+import community.whatever.onembackendjava.entity.ShortenUrl;
+import community.whatever.onembackendjava.repository.ShortenUrlRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Random;
 
 @Service
+@RequiredArgsConstructor
 public class UrlShortenService {
-    private final Map<String, String> shortenUrls = new HashMap<>();
+    
+    private final ShortenUrlRepository shortenUrlRepository;
+    private final Random random = new Random();
 
+    @Transactional(readOnly = true)
     public SearchShortenUrlResponse searchShortenUrl(SearchShortenUrlRequest request) {
-        if (!shortenUrls.containsKey(request.key())) {
-            throw new IllegalArgumentException("Invalid key");
-        }
-        return new SearchShortenUrlResponse(shortenUrls.get(request.key()));
+        ShortenUrl shortenUrl = shortenUrlRepository.findByShortenKey(request.key())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid key"));
+        
+        shortenUrlRepository.save(shortenUrl);
+        
+        return new SearchShortenUrlResponse(shortenUrl.getOriginalUrl());
     }
 
+    @Transactional
     public CreateShortenUrlResponse createShortenUrl(CreateShortenUrlRequest request) {
-        String randomKey = String.valueOf(new Random().nextInt(10000));
-        shortenUrls.put(randomKey, request.originUrl());
+
+        String randomKey;
+        do {
+            randomKey = String.valueOf(random.nextInt(10000));
+        } while (shortenUrlRepository.existsByShortenKey(randomKey));
+        
+        ShortenUrl shortenUrl = new ShortenUrl(randomKey, request.originUrl());
+        shortenUrlRepository.save(shortenUrl);
+        
         return new CreateShortenUrlResponse(randomKey);
     }
 }

--- a/src/main/java/community/whatever/onembackendjava/UrlShortenService.java
+++ b/src/main/java/community/whatever/onembackendjava/UrlShortenService.java
@@ -1,0 +1,29 @@
+package community.whatever.onembackendjava;
+
+import community.whatever.onembackendjava.dto.CreateShortenUrlRequest;
+import community.whatever.onembackendjava.dto.CreateShortenUrlResponse;
+import community.whatever.onembackendjava.dto.SearchShortenUrlRequest;
+import community.whatever.onembackendjava.dto.SearchShortenUrlResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+@Service
+public class UrlShortenService {
+    private final Map<String, String> shortenUrls = new HashMap<>();
+
+    public SearchShortenUrlResponse searchShortenUrl(SearchShortenUrlRequest request) {
+        if (!shortenUrls.containsKey(request.key())) {
+            throw new IllegalArgumentException("Invalid key");
+        }
+        return new SearchShortenUrlResponse(shortenUrls.get(request.key()));
+    }
+
+    public CreateShortenUrlResponse createShortenUrl(CreateShortenUrlRequest request) {
+        String randomKey = String.valueOf(new Random().nextInt(10000));
+        shortenUrls.put(randomKey, request.originUrl());
+        return new CreateShortenUrlResponse(randomKey);
+    }
+}

--- a/src/main/java/community/whatever/onembackendjava/dto/CreateShortenUrlRequest.java
+++ b/src/main/java/community/whatever/onembackendjava/dto/CreateShortenUrlRequest.java
@@ -5,6 +5,6 @@ import jakarta.validation.constraints.Size;
 
 public record CreateShortenUrlRequest(
     @NotBlank(message = "URL이 비어있으면 안됩니다.")
-    @Size(max = 2083, message = "URL은 2083자를 넘을 수 없습니다.")
+    @Size(max = 2048, message = "URL은 2048자를 넘을 수 없습니다.")
     String originUrl
 ) {}

--- a/src/main/java/community/whatever/onembackendjava/dto/CreateShortenUrlRequest.java
+++ b/src/main/java/community/whatever/onembackendjava/dto/CreateShortenUrlRequest.java
@@ -1,5 +1,10 @@
 package community.whatever.onembackendjava.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record CreateShortenUrlRequest(
+    @NotBlank(message = "URL이 비어있으면 안됩니다.")
+    @Size(max = 2083, message = "URL은 2083자를 넘을 수 없습니다.")
     String originUrl
 ) {}

--- a/src/main/java/community/whatever/onembackendjava/entity/ShortenUrl.java
+++ b/src/main/java/community/whatever/onembackendjava/entity/ShortenUrl.java
@@ -25,7 +25,7 @@ public class ShortenUrl {
     @Column(unique = true, nullable = false)
     private String shortenKey;
 
-    @Column(nullable = false, length = 32767)
+    @Column(nullable = false, length = 2083)
     private String originalUrl;
 
     @Column(nullable = false)

--- a/src/main/java/community/whatever/onembackendjava/entity/ShortenUrl.java
+++ b/src/main/java/community/whatever/onembackendjava/entity/ShortenUrl.java
@@ -1,0 +1,43 @@
+package community.whatever.onembackendjava.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "shorten_urls")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ShortenUrl {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String shortenKey;
+
+    @Column(nullable = false, length = 32767)
+    private String originalUrl;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column
+    private LocalDateTime lastAccessedAt;
+
+    public ShortenUrl(String shortenKey, String originalUrl) {
+        this.shortenKey = shortenKey;
+        this.originalUrl = originalUrl;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/community/whatever/onembackendjava/entity/ShortenUrl.java
+++ b/src/main/java/community/whatever/onembackendjava/entity/ShortenUrl.java
@@ -15,7 +15,6 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "shorten_urls")
 @Getter
-@Setter
 @NoArgsConstructor
 public class ShortenUrl {
 
@@ -32,6 +31,7 @@ public class ShortenUrl {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @Setter
     @Column
     private LocalDateTime lastAccessedAt;
 

--- a/src/main/java/community/whatever/onembackendjava/entity/ShortenUrl.java
+++ b/src/main/java/community/whatever/onembackendjava/entity/ShortenUrl.java
@@ -25,7 +25,7 @@ public class ShortenUrl {
     @Column(unique = true, nullable = false)
     private String shortenKey;
 
-    @Column(nullable = false, length = 2083)
+    @Column(nullable = false, length = 2048)
     private String originalUrl;
 
     @Column(nullable = false)

--- a/src/main/java/community/whatever/onembackendjava/repository/ShortenUrlRepository.java
+++ b/src/main/java/community/whatever/onembackendjava/repository/ShortenUrlRepository.java
@@ -1,0 +1,15 @@
+package community.whatever.onembackendjava.repository;
+
+import community.whatever.onembackendjava.entity.ShortenUrl;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ShortenUrlRepository extends JpaRepository<ShortenUrl, Long> {
+    
+    Optional<ShortenUrl> findByShortenKey(String shortenKey);
+    
+    boolean existsByShortenKey(String shortenKey);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,16 @@
-spring.application.name=onem-backend
+spring:
+  application:
+    name: onem-backend
+  datasource:
+    url: jdbc:postgresql://ep-withered-violet-a157m6c0.ap-southeast-1.pg.koyeb.app/koyebdb
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
# 개요
- 인메모리  --> PostgreSQL 데이터베이스
- Service로 비즈니스 로직 분리.

# 주요 변경 사항
1. PostgreSQL 연동
- 인메모리 HashMap의 경우 서버가 꺼지면 그간에 저장된 url들이 날라간다. 그런데 문서화등에 shortUrl이 쓰이는 경우 장기간 저장될 필요가 있으므로 데이터베이스를 사용함.
- 그중에서도 PostgreSQL을 고른 이유는 배포서비스에서 무료로 제공해주는게 PostgreSQL밖에 없어서임.

2. 기능 개선 및 최적화
- originalUrl 필드가 최대 [2048자까지](https://www.baeldung.com/cs/max-url-length) 지원
  - 일단 크롬에서 보여지는게 2048자까지라고도 하기 때문에 제한함.
- Random 인스턴스 재사용으로 성능 향상
- JPA 트랜잭션 관리 추가로 데이터 무결성 보장
- 중복 키 검사 로직 추가


# 향후 계획
[] 키 생성 알고리즘 개선 (현재는 0-9999 범위의 숫자만 사용)
[] URL 유효성 검증 로직 추가
[] URL 중복 저장 가능성

> [!NOTE]
> DB 아이디 비번 필요시 문의주세요.