### PR TITLE
[STEP2-1] 하나의 Controller를 service,data,repository로 분리

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ group = "community.whatever"
 version = "0.0.1-SNAPSHOT"
 val coroutinesVersion = "1.10.1"
 val awaitilityVersion = "4.2.0"
+val mockkVersion = "1.13.17"
 
 java {
     toolchain {
@@ -31,6 +32,10 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
     // awaitility은 비동기 코드를 테스트하기 위한 라이브러리입니다.
     testImplementation("org.awaitility:awaitility-kotlin:$awaitilityVersion")
+    // mockk는 목 객체를 생성하기 위한 라이브러리입니다.
+    testImplementation("io.mockk:mockk:$mockkVersion")
+    // webTestClient를 사용하기 위해 webflux를 추가합니다.
+    testImplementation("org.springframework.boot:spring-boot-starter-webflux")
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/main/kotlin/community/whatever/onembackendkotlin/ShortenedUrl.kt
+++ b/src/main/kotlin/community/whatever/onembackendkotlin/ShortenedUrl.kt
@@ -1,0 +1,3 @@
+package community.whatever.onembackendkotlin
+
+data class ShortenedUrl(val originUrl: String, val id: String? = null)

--- a/src/main/kotlin/community/whatever/onembackendkotlin/ShortenedUrlInMemoryRepository.kt
+++ b/src/main/kotlin/community/whatever/onembackendkotlin/ShortenedUrlInMemoryRepository.kt
@@ -1,0 +1,35 @@
+package community.whatever.onembackendkotlin
+
+import org.springframework.stereotype.Repository
+import java.util.concurrent.atomic.AtomicLong
+
+@Repository
+class ShortenedUrlInMemoryRepository : ShortenedUrlRepository {
+    private val shortenUrls = mutableMapOf<String, ShortenedUrl>()
+    private val seq: AtomicLong = AtomicLong()
+
+    override fun findById(id: String): ShortenedUrl? {
+        return shortenUrls[id]
+    }
+
+    override fun save(shortenedUrl: ShortenedUrl): ShortenedUrl {
+        val id = generateId()
+        return shortenedUrl.copy(id = id).also { shortenUrls[id] = it }
+    }
+
+    override fun existsByOriginUrl(originUrl: String): Boolean {
+        return shortenUrls.values.any { it.originUrl == originUrl }
+    }
+
+    override fun findByOriginUrl(originUrl: String): ShortenedUrl? {
+        return shortenUrls.values.find { it.originUrl == originUrl }
+    }
+
+    override fun deleteAll() {
+        shortenUrls.clear()
+    }
+
+    private fun generateId(): String {
+        return seq.incrementAndGet().toString()
+    }
+}

--- a/src/main/kotlin/community/whatever/onembackendkotlin/ShortenedUrlRepository.kt
+++ b/src/main/kotlin/community/whatever/onembackendkotlin/ShortenedUrlRepository.kt
@@ -1,0 +1,40 @@
+package community.whatever.onembackendkotlin
+
+interface ShortenedUrlRepository {
+    /**
+     * 아이디를 통해 원본 URL을 찾는다.
+     *
+     * @param id ShortenedUrl의 id이다.
+     * @return 존재하면 ShortenedUrl을 반환하고 존재하지 않으면 null을 반환한다.
+     */
+    fun findById(id: String): ShortenedUrl?
+
+    /**
+     * ShortenedUrl을 저장한다.
+     *
+     * @param shortenedUrl 저장할 ShortenedUrl이다.
+     * @return 저장된 ShortenedUrl을 반환한다.
+     */
+    fun save(shortenedUrl: ShortenedUrl): ShortenedUrl
+
+    /**
+     * 원본 URL을 통해 ShortenedUrl을 찾는다.
+     *
+     * @param originUrl ShortenedUrl의 원본 URL이다.
+     * @return 존재하면 ShortenedUrl을 반환하고 존재하지 않으면 null을 반환한다.
+     */
+    fun existsByOriginUrl(originUrl: String): Boolean
+
+    /**
+     * 원본 URL을 통해 ShortenedUrl을 찾는다.
+     *
+     * @param originUrl ShortenedUrl의 원본 URL이다.
+     * @return 존재하면 ShortenedUrl을 반환하고 존재하지 않으면 null을 반환한다.
+     */
+    fun findByOriginUrl(originUrl: String): ShortenedUrl?
+
+    /**
+     * 모든 ShortenedUrl을 삭제한다.
+     */
+    fun deleteAll()
+}

--- a/src/main/kotlin/community/whatever/onembackendkotlin/UrlShortenController.kt
+++ b/src/main/kotlin/community/whatever/onembackendkotlin/UrlShortenController.kt
@@ -3,21 +3,17 @@ package community.whatever.onembackendkotlin
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
-import java.util.concurrent.atomic.AtomicLong
 
 @RestController
-class UrlShortenController {
-    private val shortenUrls = mutableMapOf<String, String>()
-    private var key: AtomicLong = AtomicLong(0)
+class UrlShortenController(private val urlShortenService: UrlShortenService) {
 
     @PostMapping("/shorten-url/search")
     fun shortenUrlSearch(@RequestBody key: String): String {
-        return shortenUrls[key] ?: throw UrlNotFoundException()
+        return urlShortenService.getOriginUrl(key)
     }
 
     @PostMapping("/shorten-url/create")
     fun shortenUrlCreate(@RequestBody originUrl: String): String {
-        shortenUrls.entries.firstOrNull { it.value == originUrl }?.let { return it.key }
-        return key.getAndIncrement().toString().also { shortenUrls[it] = originUrl }
+        return urlShortenService.saveShortenUrl(originUrl)
     }
 }

--- a/src/main/kotlin/community/whatever/onembackendkotlin/UrlShortenService.kt
+++ b/src/main/kotlin/community/whatever/onembackendkotlin/UrlShortenService.kt
@@ -1,0 +1,20 @@
+package community.whatever.onembackendkotlin
+
+interface UrlShortenService {
+    /**
+     * 아이디를 통해 원본 URL을 찾는다.
+     *
+     * @param id ShortenedUrl의 id이다.
+     * @return ShortenedUrl의 id
+     * @throws UrlNotFoundException ShortenedUrl의 id에 해당하는 ShortenedUrl이 존재하지 않으면 발생한다.
+     */
+    fun getOriginUrl(id: String): String
+
+    /**
+     * URL이 존재하면 저장된 URL의 id를 반환하고 존재하지 않으면 새롭게 URL을 저장하고 id를 반환한다.
+     *
+     * @param originUrl 단축할 URL이다.
+     * @return 저장된 URL의 id이다.
+     */
+    fun saveShortenUrl(originUrl: String): String
+}

--- a/src/main/kotlin/community/whatever/onembackendkotlin/UrlShortenServiceImpl.kt
+++ b/src/main/kotlin/community/whatever/onembackendkotlin/UrlShortenServiceImpl.kt
@@ -1,0 +1,19 @@
+package community.whatever.onembackendkotlin
+
+import org.springframework.stereotype.Service
+
+@Service
+class UrlShortenServiceImpl(private val shortenedUrlRepository: ShortenedUrlRepository) : UrlShortenService {
+    override fun getOriginUrl(id: String): String {
+        return shortenedUrlRepository.findById(id)?.originUrl ?: throw UrlNotFoundException()
+    }
+
+    override fun saveShortenUrl(originUrl: String): String {
+        if (shortenedUrlRepository.existsByOriginUrl(originUrl)) {
+            return shortenedUrlRepository.findByOriginUrl(originUrl)!!.id!!
+        }
+        return shortenedUrlRepository.save(ShortenedUrl(originUrl)).id!!
+    }
+
+
+}

--- a/src/test/kotlin/community/whatever/onembackendkotlin/ShortenedUrlInMemoryRepositoryTest.kt
+++ b/src/test/kotlin/community/whatever/onembackendkotlin/ShortenedUrlInMemoryRepositoryTest.kt
@@ -1,0 +1,130 @@
+package community.whatever.onembackendkotlin
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ShortenedUrlInMemoryRepositoryTest {
+
+    private lateinit var repository: ShortenedUrlInMemoryRepository
+
+    @BeforeEach
+    fun setUp() {
+        repository = ShortenedUrlInMemoryRepository()
+    }
+
+    @DisplayName("아이디로 원본 URL을 찾기")
+    @Nested
+    inner class FindById {
+
+        @Test
+        fun `존재하는 아이디로 찾으면 해당 ShortenedUrl을 반환한다`() {
+            // given
+            val shortenedUrl = ShortenedUrl("https://www.google.com")
+            val savedShortenedUrl = repository.save(shortenedUrl)
+
+            // when
+            val foundShortenedUrl = repository.findById(savedShortenedUrl.id!!)
+
+            // then
+            assert(foundShortenedUrl == savedShortenedUrl)
+        }
+
+        @Test
+        fun `존재하지 않는 아이디로 찾으면 null을 반환한다`() {
+            // when
+            val foundShortenedUrl = repository.findById("non-exist-id")
+
+            // then
+            assert(foundShortenedUrl == null)
+        }
+    }
+
+    @DisplayName("shortenedUrl을 저장")
+    @Nested
+    inner class Save {
+
+        @Test
+        fun `ShortenedUrl을 저장하면 저장된 ShortenedUrl을 반환한다`() {
+            // given
+            val shortenedUrl = ShortenedUrl("https://www.google.com")
+
+            // when
+            val savedShortenedUrl = repository.save(shortenedUrl)
+
+            // then
+            assert(savedShortenedUrl.originUrl == shortenedUrl.originUrl)
+            assert(savedShortenedUrl.id != null)
+        }
+
+        @Test
+        fun `ShortenedUrl을 저장하면 저장된 ShortenedUrl의 id는 순차적으로 증가한다`() {
+            // given
+            val shortenedUrl1 = ShortenedUrl("https://www.google.com")
+            val shortenedUrl2 = ShortenedUrl("https://www.naver.com")
+
+            // when
+            val savedShortenedUrl1 = repository.save(shortenedUrl1)
+            val savedShortenedUrl2 = repository.save(shortenedUrl2)
+
+            // then
+            assert(savedShortenedUrl1.id == "1")
+            assert(savedShortenedUrl2.id == "2")
+        }
+    }
+
+    @DisplayName("원본 URL로 ShortenedUrl 존재 여부를 확인")
+    @Nested
+    inner class ExistsByOriginUrl {
+
+        @Test
+        fun `존재하는 원본 URL로 확인하면 true를 반환한다`() {
+            // given
+            val shortenedUrl = ShortenedUrl("https://www.google.com")
+            repository.save(shortenedUrl)
+
+            // when
+            val exists = repository.existsByOriginUrl(shortenedUrl.originUrl)
+
+            // then
+            assert(exists)
+        }
+
+        @Test
+        fun `존재하지 않는 원본 URL로 확인하면 false를 반환한다`() {
+            // when
+            val exists = repository.existsByOriginUrl("non-exist-origin-url")
+
+            // then
+            assert(!exists)
+        }
+    }
+
+    @DisplayName("원본 URL로 ShortenedUrl을 찾기")
+    @Nested
+    inner class FindByOriginUrl {
+
+        @Test
+        fun `존재하는 원본 URL로 찾으면 해당 ShortenedUrl을 반환한다`() {
+            // given
+            val shortenedUrl = ShortenedUrl("https://www.google.com")
+            val savedShortenedUrl = repository.save(shortenedUrl)
+
+            // when
+            val foundShortenedUrl = repository.findByOriginUrl(shortenedUrl.originUrl)
+
+            // then
+            assert(foundShortenedUrl == savedShortenedUrl)
+        }
+
+        @Test
+        fun `존재하지 않는 원본 URL로 찾으면 null을 반환한다`() {
+            // when
+            val foundShortenedUrl = repository.findByOriginUrl("non-exist-origin-url")
+
+            // then
+            assert(foundShortenedUrl == null)
+        }
+    }
+}

--- a/src/test/kotlin/community/whatever/onembackendkotlin/UrlShortenControllerIntegrationTest.kt
+++ b/src/test/kotlin/community/whatever/onembackendkotlin/UrlShortenControllerIntegrationTest.kt
@@ -6,6 +6,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.beans.factory.annotation.Autowired
@@ -28,27 +30,118 @@ class UrlShortenControllerIntegrationTest {
         shortenedUrlRepository.deleteAll()
     }
 
-    @ParameterizedTest
-    @CsvSource("50", "500", "10000")
-    fun `동시에 여러 개의 원본 URL을 등록해도 키가 중복되지 않는다`(count: Int) = runTest {
-        // given
-        val originUrls = (1..count).map { "https://www.google.com/$it" }
+    @DisplayName("원본 URL 조회")
+    @Nested
+    inner class ShortenUrlSearch {
 
-        // when
-        val keys = originUrls.map { async { createUrl(it) } }
+        @ParameterizedTest
+        @CsvSource(
+            "https://www.google.com",
+            "https://www.naver.com",
+            "https://www.daum.net"
+        )
+        fun `등록된 원본 URL을 키로 검색하면 해당 원본 URL을 반환한다`(originUrl: String) = runTest {
+            // given
+            val key = createUrl(originUrl)
+                .expectBody(String::class.java)
+                .returnResult()
+                .responseBody!!
 
-        // then
-        await untilAsserted { assertThat(keys).hasSize(count).doesNotHaveDuplicates() }
+            // when
+            val result = searchShortenUrl(key)
+
+            // then
+            result.expectStatus().isOk()
+                .expectBody(String::class.java)
+                .isEqualTo(originUrl)
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            "https://www.google.com",
+            "https://www.naver.com",
+            "https://www.daum.net"
+        )
+        fun `등록되지 않은 원본 URL을 키로 검색하면 404를 반환한다`(originUrl: String) = runTest {
+            // given
+            val key = "non-exist-key"
+
+            // when
+            val result = searchShortenUrl(key)
+
+            // then
+            result.expectStatus()
+                .isNotFound()
+        }
     }
 
-    private fun createUrl(originUrl: String): String? {
-        return webTestClient.post()
-            .uri("/shorten-url/create")
-            .bodyValue(originUrl)
-            .exchange()
-            .expectStatus().isOk
-            .expectBody(String::class.java)
-            .returnResult()
-            .responseBody
+    @DisplayName("원본 URL 등록")
+    @Nested
+    inner class ShortenUrlCreate {
+
+        @ParameterizedTest
+        @CsvSource(
+            "https://www.google.com",
+            "https://www.naver.com",
+            "https://www.daum.net"
+        )
+        fun `원본 URL을 등록하면 키를 반환한다`(originUrl: String) = runTest {
+            // when
+            val result = createUrl(originUrl)
+
+            // then
+            val key = result.expectStatus().isOk()
+                .expectBody(String::class.java)
+                .returnResult()
+                .responseBody!!
+            assertThat(key).isNotBlank()
+        }
+
+        @ParameterizedTest
+        @CsvSource("50", "100")
+        fun `동시에 여러 개의 원본 URL을 등록해도 키가 중복되지 않는다`(count: Int) = runTest {
+            // given
+            val originUrls = (1..count).map { "https://www.google.com/$it" }
+
+            // when
+            val keys = originUrls.map { async { createUrlAndReturnKey(it) } }
+
+            // then
+            await untilAsserted { assertThat(keys).hasSize(count).doesNotHaveDuplicates() }
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            "https://www.google.com",
+            "https://www.naver.com",
+            "https://www.daum.net"
+        )
+        fun `등록된 원본 URL을 다시 등록하면 기존 키를 반환한다`(originUrl: String) = runTest {
+            // given
+            val key = createUrlAndReturnKey(originUrl)
+
+            // when
+            val result = createUrl(originUrl)
+
+            // then
+            result.expectStatus().isOk()
+                .expectBody(String::class.java)
+                .isEqualTo(key)
+        }
     }
+
+    private fun searchShortenUrl(key: String) = webTestClient.post()
+        .uri("/shorten-url/search")
+        .bodyValue(key)
+        .exchange()
+
+    private fun createUrl(originUrl: String) = webTestClient.post()
+        .uri("/shorten-url/create")
+        .bodyValue(originUrl)
+        .exchange()
+
+    private fun createUrlAndReturnKey(originUrl: String) = createUrl(originUrl)
+        .expectBody(String::class.java)
+        .returnResult()
+        .responseBody!!
 }

--- a/src/test/kotlin/community/whatever/onembackendkotlin/UrlShortenControllerTest.kt
+++ b/src/test/kotlin/community/whatever/onembackendkotlin/UrlShortenControllerTest.kt
@@ -2,21 +2,29 @@ package community.whatever.onembackendkotlin
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(UrlShortenController::class)
 class UrlShortenControllerTest(
-    @Autowired private val mockMvc: MockMvc
+    @Autowired private val mockMvc: MockMvc,
 ) {
+
+    @MockitoBean
+    private lateinit var urlShortenService: UrlShortenService
+
     @Test
     fun `원본 URL 등록 시 키를 반환한다`() {
         // given
         val originUrl = "https://www.google.com"
+        val key = "123"
+        given(urlShortenService.saveShortenUrl(originUrl)).willReturn(key)
 
         // when
         val result = mockMvc.perform(
@@ -37,15 +45,8 @@ class UrlShortenControllerTest(
     fun `키로 검색하면 원본 URL을 반환한다`() {
         // given
         val originUrl = "https://www.google.com"
-        val key = mockMvc.perform(
-            post("/shorten-url/create")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(originUrl)
-        )
-            .andExpect(status().isOk)
-            .andReturn()
-            .response
-            .contentAsString
+        val key = "123"
+        given(urlShortenService.getOriginUrl(key)).willReturn(originUrl)
 
         // when
         val result = mockMvc.perform(
@@ -66,6 +67,7 @@ class UrlShortenControllerTest(
     fun `유요하지 않은 키로 검색하면 404 에러를 반환한다`() {
         // given
         val invalidKey = "invalid-key"
+        given(urlShortenService.getOriginUrl(invalidKey)).willThrow(UrlNotFoundException())
 
         // when
         mockMvc.perform(
@@ -80,15 +82,8 @@ class UrlShortenControllerTest(
     fun `중복된 원본 URL을 등록하면 기존 키를 반환한다`() {
         // given
         val originUrl = "https://www.google.com"
-        val key = mockMvc.perform(
-            post("/shorten-url/create")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(originUrl)
-        )
-            .andExpect(status().isOk)
-            .andReturn()
-            .response
-            .contentAsString
+        val key = "123"
+        given(urlShortenService.saveShortenUrl(originUrl)).willReturn(key)
 
         // when
         val result = mockMvc.perform(

--- a/src/test/kotlin/community/whatever/onembackendkotlin/UrlShortenServiceImplTest.kt
+++ b/src/test/kotlin/community/whatever/onembackendkotlin/UrlShortenServiceImplTest.kt
@@ -1,0 +1,103 @@
+package community.whatever.onembackendkotlin
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("UrlShortenServiceImpl 테스트")
+class UrlShortenServiceImplTest {
+
+    private val shortenedUrlRepository: ShortenedUrlRepository = mockk()
+    private val urlShortenService = UrlShortenServiceImpl(shortenedUrlRepository)
+
+    @DisplayName("ShortenedUrl 저장")
+    @Nested
+    inner class SaveShortenUrl {
+
+        private lateinit var originUrl: String
+        private lateinit var id: String
+        private lateinit var shortenedUrl: ShortenedUrl
+        private lateinit var savedShortenedUrl: ShortenedUrl
+
+        @BeforeEach
+        fun setUp() {
+            originUrl = "https://www.google.com"
+            id = "abc"
+            shortenedUrl = ShortenedUrl(originUrl)
+            savedShortenedUrl = shortenedUrl.copy(id = id)
+        }
+
+        @Test
+        fun `저장된 url이 없으면 새로 저장하고 키를 반환한다`() {
+            // given
+            every { shortenedUrlRepository.existsByOriginUrl(originUrl) } returns false
+            every { shortenedUrlRepository.save(shortenedUrl) } returns savedShortenedUrl
+
+            // when
+            val result = urlShortenService.saveShortenUrl(originUrl)
+
+            // then
+            assertThat(result).isEqualTo(id)
+            verify { shortenedUrlRepository.save(shortenedUrl) }
+        }
+
+        @Test
+        fun `이미 저장된 url이 있으면 찾아서 키를 반환한다`() {
+            // given
+            every { shortenedUrlRepository.existsByOriginUrl(originUrl) } returns true
+            every { shortenedUrlRepository.findByOriginUrl(originUrl) } returns savedShortenedUrl
+
+            // when
+            val result = urlShortenService.saveShortenUrl(originUrl)
+
+            // then
+            assertThat(result).isEqualTo(id)
+            verify { shortenedUrlRepository.findByOriginUrl(originUrl) }
+        }
+    }
+
+    @DisplayName("원본 URL을 찾기")
+    @Nested
+    inner class GetOriginUrl {
+
+        private lateinit var id: String
+        private lateinit var originUrl: String
+        private lateinit var shortenedUrl: ShortenedUrl
+
+        @BeforeEach
+        fun setUp() {
+            id = "abc"
+            originUrl = "https://www.google.com"
+            shortenedUrl = ShortenedUrl(originUrl, id)
+        }
+
+        @Test
+        fun `id에 해당하는 원본 URL을 찾아서 반환한다`() {
+            // given
+            every { shortenedUrlRepository.findById(id) } returns shortenedUrl
+
+            // when
+            val result = urlShortenService.getOriginUrl(id)
+
+            // then
+            assertThat(result).isEqualTo(originUrl)
+            verify { shortenedUrlRepository.findById(id) }
+        }
+
+        @Test
+        fun `id에 해당하는 원본 URL이 없으면 예외를 발생시킨다`() {
+            // given
+            every { shortenedUrlRepository.findById(id) } returns null
+
+            // when, then
+            assertThatThrownBy { urlShortenService.getOriginUrl(id) }.isInstanceOf(UrlNotFoundException::class.java)
+            verify { shortenedUrlRepository.findById(id) }
+        }
+    }
+}


### PR DESCRIPTION
## 개선사항

- [x] 하나의 Controller를 service, repository로 분리

```mermaid
sequenceDiagram
    participant U as User
    participant C as UrlShortenerController
    participant S as UrlShortenerService
    participant R as ShortUrlRepository

    par Original Url 저장
        U ->> C: Original Url 저장 요청
        C ->> S: Original Url 저장 요청
        S ->> R: Original Url 저장
        R -->> S: Original Url 저장후 Key 반환
        S -->> C: Key 반환
        C -->> U: Key 반환
    end

    par Original Url 조회
        U ->> C: Original Url 조회 요청
        C ->> S: Original Url 조회 요청
        alt key가 존재 할 경우
            S ->> R: Original Url 조회
            R -->> S: Original Url 반환
            S -->> C: Original Url 반환
            C -->> U: Original Url 반환
        else key가 존재하지 않을 경우
            S ->> R: Original Url 조회
            R -->> S: Original Url 조회 실패
            S -->> C: 에러 발생
            C -->> U: 404 응답
        end
    end
```

## 기타

- WebFlux를 추가하여 통합 테스트에 WebTestClient를 사용하여 속도 향상 기대