### PR TITLE
fix: originUrl 조회에 실패한 경우에도 정상 응답을 하는 오류 수정

### DIFF
--- a/src/main/java/community/whatever/onembackendjava/application/UrlShortenServiceImpl.java
+++ b/src/main/java/community/whatever/onembackendjava/application/UrlShortenServiceImpl.java
@@ -19,11 +19,8 @@ public class UrlShortenServiceImpl implements UrlShortenService {
 
     @Override
     public String getOriginalUrl(final String shortUrl) throws IllegalArgumentException {
-        try {
-            return urlShortenRepository.getOriginUrl(shortUrl);
-        } catch (NullPointerException ne) {
-            throw new IllegalArgumentException("Invalid key");
-        }
+        return urlShortenRepository.getOriginUrl(shortUrl)
+                .orElseThrow();
     }
 
     @Override

--- a/src/main/java/community/whatever/onembackendjava/repository/InMemoryRepository.java
+++ b/src/main/java/community/whatever/onembackendjava/repository/InMemoryRepository.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @Component
 public class InMemoryRepository implements UrlShortenRepository {
@@ -11,8 +12,8 @@ public class InMemoryRepository implements UrlShortenRepository {
     private final Map<String, String> shortenUrls = new HashMap<>();
 
     @Override
-    public String getOriginUrl(final String shortenUrl) {
-        return shortenUrls.get(shortenUrl);
+    public Optional<String> getOriginUrl(final String shortenUrl) {
+        return Optional.ofNullable(shortenUrls.get(shortenUrl));
     }
 
     @Override

--- a/src/main/java/community/whatever/onembackendjava/repository/UrlShortenRepository.java
+++ b/src/main/java/community/whatever/onembackendjava/repository/UrlShortenRepository.java
@@ -1,8 +1,10 @@
 package community.whatever.onembackendjava.repository;
 
+import java.util.Optional;
+
 public interface UrlShortenRepository {
 
-    String getOriginUrl(final String shortenUrl);
+    Optional<String> getOriginUrl(final String shortenUrl);
 
     void createShortenUrl(final String originUrl, final String key);
 

--- a/src/test/java/community/whatever/onembackendjava/OnemBackendApplicationTests.java
+++ b/src/test/java/community/whatever/onembackendjava/OnemBackendApplicationTests.java
@@ -1,13 +1,56 @@
 package community.whatever.onembackendjava;
 
+import community.whatever.onembackendjava.application.RandomKeyGenerator;
+import community.whatever.onembackendjava.application.UrlShortenServiceImpl;
+import community.whatever.onembackendjava.repository.UrlShortenRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class OnemBackendApplicationTests {
 
+    private UrlShortenRepository urlShortenRepository;
+    private RandomKeyGenerator randomKeyGenerator;
+    private UrlShortenServiceImpl urlShortenService;
+
+    @BeforeEach
+    void setUp() {
+        urlShortenRepository = Mockito.mock(UrlShortenRepository.class);
+        randomKeyGenerator = Mockito.mock(RandomKeyGenerator.class);
+        urlShortenService = new UrlShortenServiceImpl(urlShortenRepository, randomKeyGenerator);
+    }
+
+    // Repository 에서 ShortUrl 을 찾지 못한 경우 NoSuchElementException 이 발생하는지 테스트
     @Test
-    void contextLoads() {
+    void testGetOriginalUrl_WhenShortUrlNotFound_ShouldThrowException() {
+        String shortUrl = "1234";
+        Mockito.when(urlShortenRepository.getOriginUrl(shortUrl)).thenReturn(Optional.empty());
+
+        NoSuchElementException exception = assertThrows(NoSuchElementException.class, () -> {
+            urlShortenService.getOriginalUrl(shortUrl);
+        });
+
+        assertEquals("No value present", exception.getMessage());
+    }
+
+    // Repository 에서 ShortUrl 을 찾은 경우, 정상적으로 OriginalUrl 을 반환하는지 테스트
+    @Test
+    void testGetOriginalUrl_WhenShortUrlFound_ShouldReturnOriginalUrl() {
+        String shortUrl = "1234";
+        String originalUrl = "http://www.google.com";
+        Mockito.when(urlShortenRepository.getOriginUrl(shortUrl)).thenReturn(Optional.of(originalUrl));
+
+        String result = urlShortenService.getOriginalUrl(shortUrl);
+
+        assertEquals(originalUrl, result);
     }
 
 }


### PR DESCRIPTION
## 배경
- #89 를 통해 의도치않게 기능이 수정되며 이상동작 확인
- 찾는 값이 없는 경우 null 이 반환되며, 아무런 처리 없이 전달되어 최종적으로 클라이언트에 정상 응답을 반환 (200, OK)
- 정상 응답임에도 response body 는 비어있어 클라이언트에서 오류가 발생할 가능성이 높다고 판단

## 변경점
- Repository 의 get 메서드에 대한 반환형을 Optional 로 wrapping 하도록 수정
- Service 에 wrapper 객체를 통해 값이 null 인 경우 NoSuchElementException 예외를 던지도록 수정
- 재발 방지 목적으로 관련 테스트 케이스 2건 작성

## 잘못된 점
1. 구조 변경 과정에서 기능이 수정되어, 원하지 않는 동작이 발생함
    - 테스트 코드를 먼저 작성, 수행하여 반복되지 않도록 해야겠습니다
2. 인터페이스 수정
    - 앞으로는 인터페이스를 설계할 때 가능한 한 많은 요소들을 고려해야겠습니다
    - 다행히.. 현재로써는 부담 되지않는 선에서 연관된 코드들의 수정이 가능했습니다