### PR TITLE
[STEP 3-1-1] 만료시간 추가

### DIFF
--- a/http_test/UrlShortenController.http
+++ b/http_test/UrlShortenController.http
@@ -3,7 +3,8 @@ POST http://localhost:8080/shorten-url
 Content-Type: application/json
 
 {
-  "originURL": "https://www.naver.com"
+  "originURL": "https://wwws.naver.com",
+  "ttlMinutes": 10
 }
 
 > {%

--- a/src/main/java/community/whatever/onembackendjava/controller/UrlShortenController.java
+++ b/src/main/java/community/whatever/onembackendjava/controller/UrlShortenController.java
@@ -39,9 +39,7 @@ public class UrlShortenController {
 	 */
 	@PostMapping("/shorten-url")
 	public ShortenedURLCreateResponse createShortenedURL(@RequestBody @Valid ShortenedURLCreateRequest req) {
-		String originUrl = req.originURL();
-		String shortenedURL = service.createShortenedURL(originUrl);
-		ShortenedURLCreateResponse res = new ShortenedURLCreateResponse(shortenedURL);
+		ShortenedURLCreateResponse res = service.createShortenedURL(req);
 		return res;
 	}
 

--- a/src/main/java/community/whatever/onembackendjava/dto/req/ShortenedURLCreateRequest.java
+++ b/src/main/java/community/whatever/onembackendjava/dto/req/ShortenedURLCreateRequest.java
@@ -3,14 +3,16 @@ package community.whatever.onembackendjava.dto.req;
 import community.whatever.onembackendjava.controller.customValidator.ValidURL;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 public record ShortenedURLCreateRequest(
 	@ValidURL
 	String originURL,
 
+	@NotNull(message = "만료기간은 필수입니다")
 	@Min(value = 0, message = "만료 기간은 음수일 수 없습니다.")
 	@Max(value = 1440, message = "만료 기간은 최대 하루(1440분) 입니다.")
-	int ttlMinutes
+	Integer ttlMinutes
 
 ) {
 }

--- a/src/main/java/community/whatever/onembackendjava/dto/req/ShortenedURLCreateRequest.java
+++ b/src/main/java/community/whatever/onembackendjava/dto/req/ShortenedURLCreateRequest.java
@@ -1,10 +1,16 @@
 package community.whatever.onembackendjava.dto.req;
 
 import community.whatever.onembackendjava.controller.customValidator.ValidURL;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 
 public record ShortenedURLCreateRequest(
 	@ValidURL
-	String originURL
+	String originURL,
+
+	@Min(value = 0, message = "만료 기간은 음수일 수 없습니다.")
+	@Max(value = 1440, message = "만료 기간은 최대 하루(1440분) 입니다.")
+	int ttlMinutes
 
 ) {
 }

--- a/src/main/java/community/whatever/onembackendjava/dto/res/ShortenedURLCreateResponse.java
+++ b/src/main/java/community/whatever/onembackendjava/dto/res/ShortenedURLCreateResponse.java
@@ -1,7 +1,17 @@
 package community.whatever.onembackendjava.dto.res;
 
-public record ShortenedURLCreateResponse(
-	String shortenedURL
+import java.time.LocalDateTime;
 
+import community.whatever.onembackendjava.entity.ShortenedURLEntity;
+
+public record ShortenedURLCreateResponse(
+	Long id,
+	String originURL,
+	String shortenedURL,
+	LocalDateTime expiredAt
 ) {
+	public static ShortenedURLCreateResponse from(ShortenedURLEntity entity) {
+		return new ShortenedURLCreateResponse(entity.getId(), entity.getOriginURL(), entity.getShortenedURL(),
+			entity.getExpiredAt());
+	}
 }

--- a/src/main/java/community/whatever/onembackendjava/entity/ShortenedURLEntity.java
+++ b/src/main/java/community/whatever/onembackendjava/entity/ShortenedURLEntity.java
@@ -1,0 +1,32 @@
+package community.whatever.onembackendjava.entity;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ShortenedURLEntity {
+
+	private Long id;
+
+	private String originURL;
+
+	private String shortenedURL;
+
+	private LocalDateTime expiredAt;
+
+	private boolean isDeleted;
+
+	@Builder
+	public ShortenedURLEntity(Long id, String originURL, String shortenedURL, LocalDateTime expiredAt) {
+		this.id = id;
+		this.originURL = originURL;
+		this.shortenedURL = shortenedURL;
+		this.expiredAt = expiredAt;
+	}
+
+	public void markDelete() {
+		this.isDeleted = true;
+	}
+}

--- a/src/main/java/community/whatever/onembackendjava/entity/ShortenedURLEntity.java
+++ b/src/main/java/community/whatever/onembackendjava/entity/ShortenedURLEntity.java
@@ -1,5 +1,7 @@
 package community.whatever.onembackendjava.entity;
 
+import static lombok.AccessLevel.*;
+
 import java.time.LocalDateTime;
 
 import lombok.Builder;
@@ -16,17 +18,24 @@ public class ShortenedURLEntity {
 
 	private LocalDateTime expiredAt;
 
-	private boolean isDeleted;
+	private boolean disabled;
 
-	@Builder
-	public ShortenedURLEntity(Long id, String originURL, String shortenedURL, LocalDateTime expiredAt) {
-		this.id = id;
+	@Builder(access = PRIVATE)
+	private ShortenedURLEntity(String originURL, String shortenedURL, LocalDateTime expiredAt) {
 		this.originURL = originURL;
 		this.shortenedURL = shortenedURL;
 		this.expiredAt = expiredAt;
 	}
 
-	public void markDelete() {
-		this.isDeleted = true;
+	public static ShortenedURLEntity of(String originURL, String shortenedURL, LocalDateTime expiredAt) {
+		return ShortenedURLEntity.builder()
+			.originURL(originURL)
+			.shortenedURL(shortenedURL)
+			.expiredAt(expiredAt)
+			.build();
+	}
+
+	public void disable() {
+		this.disabled = true;
 	}
 }

--- a/src/main/java/community/whatever/onembackendjava/repository/URLShortenRepository.java
+++ b/src/main/java/community/whatever/onembackendjava/repository/URLShortenRepository.java
@@ -2,22 +2,23 @@ package community.whatever.onembackendjava.repository;
 
 import java.util.Optional;
 
+import community.whatever.onembackendjava.entity.ShortenedURLEntity;
+
 public interface URLShortenRepository {
 	/**
-	 * <p> 단축 URL로 저장되어 있는 원본 URL 조회</p>
+	 * <p> 단축된 URL로 조회</p>
 	 *
-	 * @param shortenedURL 단축 URL
-	 * @return 원본 URL
+	 * @param shortenedURL 단축된 URL
+	 * @return 단축 URL entity
 	 */
-	Optional<String> findByShortenedURL(String shortenedURL);
+	Optional<ShortenedURLEntity> findByShortenedURL(String shortenedURL);
 
 	/**
 	 * <p>원본 URL과 단축 URL을 저장</p>
 	 *
-	 * @param originURL    저장할 원본 URL
-	 * @param shortenedURL 저장할 단축 URL
-	 * @return 저장된 단축 URL
+	 * @param shortenedURLEntity 저장할 단축 URL 객체
+	 * @return 저장된 단축 URL entity
 	 */
-	String save(String originURL, String shortenedURL);
+	ShortenedURLEntity save(ShortenedURLEntity shortenedURLEntity);
 
 }

--- a/src/main/java/community/whatever/onembackendjava/repository/impl/URLShortenInMemoryRepository.java
+++ b/src/main/java/community/whatever/onembackendjava/repository/impl/URLShortenInMemoryRepository.java
@@ -6,23 +6,23 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.stereotype.Repository;
 
+import community.whatever.onembackendjava.entity.ShortenedURLEntity;
 import community.whatever.onembackendjava.repository.URLShortenRepository;
 
 @Repository
 public class URLShortenInMemoryRepository implements URLShortenRepository {
 
-	private final Map<String, String> shortenUrls = new ConcurrentHashMap<>();
+	private final Map<String, ShortenedURLEntity> shortenUrls = new ConcurrentHashMap<>();
 
 	@Override
-	public Optional<String> findByShortenedURL(String shortenedURL) {
-		String originURL = shortenUrls.get(shortenedURL);
-		return Optional.ofNullable(originURL);
+	public Optional<ShortenedURLEntity> findByShortenedURL(String shortenedURL) {
+		return Optional.ofNullable(shortenUrls.get(shortenedURL));
 	}
 
 	@Override
-	public String save(String originURL, String shortenedURL) {
-		shortenUrls.put(shortenedURL, originURL);
+	public ShortenedURLEntity save(ShortenedURLEntity shortenedURLEntity) {
+		shortenUrls.put(shortenedURLEntity.getShortenedURL(), shortenedURLEntity);
 
-		return shortenedURL;
+		return shortenedURLEntity;
 	}
 }

--- a/src/main/java/community/whatever/onembackendjava/service/ShortenURLService.java
+++ b/src/main/java/community/whatever/onembackendjava/service/ShortenURLService.java
@@ -54,11 +54,9 @@ public class ShortenURLService {
 		}
 		String generatedShortenedURL = generateShortenedURL();
 
-		ShortenedURLEntity shortenedURLEntity = ShortenedURLEntity.builder()
-			.originURL(req.originURL())
-			.shortenedURL(generatedShortenedURL)
-			.expiredAt(getExpirationTime(req.ttlMinutes()))
-			.build();
+		LocalDateTime expiredAt = getExpirationTime(req.ttlMinutes());
+		ShortenedURLEntity shortenedURLEntity = ShortenedURLEntity.of(req.originURL(), generatedShortenedURL,
+			expiredAt);
 		ShortenedURLEntity created = repository.save(shortenedURLEntity);
 
 		return ShortenedURLCreateResponse.from(created);

--- a/src/main/java/community/whatever/onembackendjava/service/ShortenURLService.java
+++ b/src/main/java/community/whatever/onembackendjava/service/ShortenURLService.java
@@ -1,9 +1,13 @@
 package community.whatever.onembackendjava.service;
 
+import java.time.LocalDateTime;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.springframework.stereotype.Service;
 
+import community.whatever.onembackendjava.dto.req.ShortenedURLCreateRequest;
+import community.whatever.onembackendjava.dto.res.ShortenedURLCreateResponse;
+import community.whatever.onembackendjava.entity.ShortenedURLEntity;
 import community.whatever.onembackendjava.exception.BusinessExceptionCode;
 import community.whatever.onembackendjava.exception.BusinessLogicException;
 import community.whatever.onembackendjava.repository.BlockedDomainRepository;
@@ -29,28 +33,35 @@ public class ShortenURLService {
 	 * @throws BusinessLogicException 원본 URL을 찾을 수 없는 경우
 	 */
 	public String getOriginURL(String shortenedURL) {
-		String originURL = repository.findByShortenedURL(shortenedURL)
+		ShortenedURLEntity entity = repository.findByShortenedURL(shortenedURL)
+			.filter((se) -> se.getExpiredAt().isAfter(LocalDateTime.now()))
 			.orElseThrow(() -> BusinessLogicException.from(BusinessExceptionCode.ORIGIN_URL_NOT_FOUND));
 
-		return originURL;
+		return entity.getOriginURL();
 	}
 
 	/**
 	 * <p> 원본 URL로 단축 URL 생성</p>
 	 *
-	 * @param originURL 원본 URL
+	 * @param req ShortenedURLCreateRequest
 	 * @return 생성된 단축 URL
 	 * @throws BusinessLogicException 해당 URL 도메인이 블랙리스트에 있을 경우
 	 */
-	public String createShortenedURL(String originURL) {
-		if (checkDomainInBlackList(originURL)) {
+	public ShortenedURLCreateResponse createShortenedURL(ShortenedURLCreateRequest req) {
+		if (checkDomainInBlackList(req.originURL())) {
 			throw BusinessLogicException.withAdditionalInfo(BusinessExceptionCode.IS_BLOCKED_DOMAIN,
-				"originURL: %s".formatted(originURL));
+				"originURL: %s".formatted(req.originURL()));
 		}
 		String generatedShortenedURL = generateShortenedURL();
-		String shortenedURL = repository.save(originURL, generatedShortenedURL);
 
-		return shortenedURL;
+		ShortenedURLEntity shortenedURLEntity = ShortenedURLEntity.builder()
+			.originURL(req.originURL())
+			.shortenedURL(generatedShortenedURL)
+			.expiredAt(getExpirationTime(req.ttlMinutes()))
+			.build();
+		ShortenedURLEntity created = repository.save(shortenedURLEntity);
+
+		return ShortenedURLCreateResponse.from(created);
 	}
 
 	/**
@@ -65,6 +76,10 @@ public class ShortenURLService {
 	private boolean checkDomainInBlackList(String originURL) {
 		String domain = URLUtils.extractDomainFromURL(originURL);
 		return blockedDomainRepository.exists(domain);
+	}
+
+	private LocalDateTime getExpirationTime(int ttlMinutes) {
+		return LocalDateTime.now().plusMinutes(ttlMinutes);
 	}
 
 }


### PR DESCRIPTION
- api 사용자가 단축 url을 만들 때, ttlMinutes를 추가할 수 있도록 변경
- 원래는 단축된 URL만 저장했으나, 요구사항의 변경에 따라 ID, 원본URL, 단축URL, expiredAt 을 한번에 저장하도록 변경
- 만료시간이 지난 URL은 조회할 수 없도록 변경 (추후에 스케줄링을 통한 논리적 삭제로 변경 예정)