### PR TITLE
feat: 예상되는 오류를 핸들링하기 위한 클래스 구현

### DIFF
--- a/src/main/java/community/whatever/onembackendjava/ExpectedExceptionHandler.java
+++ b/src/main/java/community/whatever/onembackendjava/ExpectedExceptionHandler.java
@@ -1,0 +1,24 @@
+package community.whatever.onembackendjava;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+public class ExpectedExceptionHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(ExpectedExceptionHandler.class);
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(exception = NoSuchElementException.class)
+    public String handleNoSuchElementException(final NoSuchElementException e) {
+        logger.error("Expected exception class: {}, message: {}", e.getClass().getName(), e.getMessage());
+        return e.getMessage();
+    }
+
+}

--- a/src/main/java/community/whatever/onembackendjava/LoggingFilter.java
+++ b/src/main/java/community/whatever/onembackendjava/LoggingFilter.java
@@ -47,7 +47,9 @@ public class LoggingFilter extends OncePerRequestFilter {
             responseWrapper.copyBodyToResponse();
         }
 
-        if (responseWrapper.getStatus() == HttpServletResponse.SC_OK) return;
+        if (responseWrapper.getStatus() == HttpServletResponse.SC_OK) {
+            return;
+        }
 
         StringBuffer stringBuffer = new StringBuffer();
         appendRequestLog(requestWrapper, stringBuffer);


### PR DESCRIPTION
## 변경 이유
- service layer 에서 발생하는 예외에 대해 response status 500 으로만 응답하는 상태
- 위의 이유로 클라이언트는 유저에게 적절한 사유를 전달할 수 없음

## 변경 내용
- 예상되는 오류 발생 시 적절한 http status 를 내려주기 위해 ExpectedExceptionHandler 를 작성했습니다.
- 예기치 않은 오류, 예상되는 오류를 모두 logging 하기 위해 기존의 LoggingFilter 를 수정했습니다.

## 개선되는 점
- 서버에서 예상되는 오류를 핸들링할 수 있게되며, 이를 통해 response status 를 적절히 내려줄 수 있게 됨
- 클라이언트는 request 내용과 서버의 response 상태를 종합해 유저에게 적절한 실패 사유를 전달할 수 있음
- 서버에서는 예기치 못한 오류와 예상되는 오류를 다른 형태로 logging 하게 되어 좀 더 명확하게 분석이 가능해질 것으로 예상 됨