### PR TITLE
feat: 키 생성 방식 수정

### DIFF
--- a/src/main/java/community/whatever/onembackendjava/application/Base62Converter.java
+++ b/src/main/java/community/whatever/onembackendjava/application/Base62Converter.java
@@ -1,0 +1,30 @@
+package community.whatever.onembackendjava.application;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class Base62Converter {
+    private static final String BASE62_CHARACTERS = "jZi7gR1q8WBpKyDXA5m0fhL9xC2szNUoVldE6wtkG3O4bTnMeHPvaIFcSYQJru";
+    private static final int BASE62 = 62;
+
+    public String encode(long value) {
+        StringBuffer sb = new StringBuffer();
+
+        while (value > 0) {
+            sb.append(BASE62_CHARACTERS.charAt((int) (value % BASE62)));
+            value /= BASE62;
+        }
+
+        return sb.reverse().toString();
+    }
+
+    public long decode(String base62String) {
+        long value = 0;
+
+        for (char c : base62String.toCharArray()) {
+            value = value * BASE62 + BASE62_CHARACTERS.indexOf(c);
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/community/whatever/onembackendjava/application/RandomKeyGeneratorImpl.java
+++ b/src/main/java/community/whatever/onembackendjava/application/RandomKeyGeneratorImpl.java
@@ -2,8 +2,6 @@ package community.whatever.onembackendjava.application;
 
 import org.springframework.stereotype.Service;
 
-import java.util.Random;
-
 @Service
 public class RandomKeyGeneratorImpl implements RandomKeyGenerator {
 

--- a/src/main/java/community/whatever/onembackendjava/application/RandomKeyGeneratorImpl.java
+++ b/src/main/java/community/whatever/onembackendjava/application/RandomKeyGeneratorImpl.java
@@ -7,10 +7,14 @@ import java.util.Random;
 @Service
 public class RandomKeyGeneratorImpl implements RandomKeyGenerator {
 
-    private final Random random = new Random();
+    private final Base62Converter base62Converter;
+
+    public RandomKeyGeneratorImpl(Base62Converter base62Converter) {
+        this.base62Converter = base62Converter;
+    }
 
     @Override
     public String getRandomKey() {
-        return String.valueOf(random.nextInt(10000));
+        return base62Converter.encode(System.currentTimeMillis());
     }
 }

--- a/src/test/java/community/whatever/onembackendjava/OnemBackendApplicationTests.java
+++ b/src/test/java/community/whatever/onembackendjava/OnemBackendApplicationTests.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -72,7 +71,7 @@ class OnemBackendApplicationTests {
         }
     }
 
-    // 생성된 shortUrl 의 길이가 7자리인지 테스트
+    // 생성된 shortUrl 의 길이가 7자리인지
     @Test
     void testCreateShortUrl_always_7digit() {
         String[] originalUrls = {"https://www.google.com", "https://www.naver.com", "https://www.daum.net"};
@@ -81,6 +80,16 @@ class OnemBackendApplicationTests {
             String result = urlShortenService.createShortUrl(originalUrl);
             assertEquals(7, result.length());
         }
+    }
+
+    // 생성된 shortUrl 이 8자리가 되는 시점 테스트
+    @Test
+    void testCreateShortUrl_8digit() {
+        long value = 3521614606208L; // Tue Aug 05 2081 10:16:46 GMT+0000
+        String encoded = base62Converter.encode(value);
+
+        System.out.printf("original: %d, encoded: %s, length: %d%n", value, encoded, encoded.length());
+        assertEquals(8, encoded.length());
     }
 
 }


### PR DESCRIPTION
생성되는 key 를 기존 최대 4자리의 난수에서
epoch time (ms) 를 base62 인코딩한 값으로 변경

- 중복 제거 후 1초당 최대 1,000건의 key 가 기록될 수 있습니다.
- 대략 2081년 전까지 7자리의 고정된 문자열을 key 로 사용할 수 있습니다.