### PR TITLE
fix: 테스트 코드 수정

### DIFF
--- a/src/test/java/community/whatever/onembackendjava/OnemBackendApplicationTests.java
+++ b/src/test/java/community/whatever/onembackendjava/OnemBackendApplicationTests.java
@@ -114,11 +114,14 @@ class OnemBackendApplicationTests {
     void testCreateShortUrl_8digit() {
         base62Converter = new Base62Converter();
 
-        long value = 3521614606208L; // Tue Aug 05 2081 10:16:46 GMT+0000
-        String encoded = base62Converter.encode(value);
+        long value = 3521614606207L; // Tue Aug 05 2081 10:16:46 GMT+0000
+        String encoded7digit = base62Converter.encode(value);
+        String encoded8digit = base62Converter.encode(value + 1);
 
-        System.out.printf("original: %d, encoded: %s, length: %d%n", value, encoded, encoded.length());
-        assertEquals(8, encoded.length());
+        System.out.printf("original: %d, encoded: %s, length: %d%n", value, encoded7digit, encoded7digit.length());
+        System.out.printf("original: %d, encoded: %s, length: %d%n", value, encoded8digit, encoded8digit.length());
+        assertEquals(7, encoded7digit.length());
+        assertEquals(8, encoded8digit.length());
     }
 
 }

--- a/src/test/java/community/whatever/onembackendjava/OnemBackendApplicationTests.java
+++ b/src/test/java/community/whatever/onembackendjava/OnemBackendApplicationTests.java
@@ -26,14 +26,16 @@ class OnemBackendApplicationTests {
     @BeforeEach
     void setUp() {
         urlShortenRepository = Mockito.mock(UrlShortenRepository.class);
-        base62Converter = new Base62Converter();
-        randomKeyGenerator = new RandomKeyGeneratorImpl(base62Converter);
-        urlShortenService = new UrlShortenServiceImpl(urlShortenRepository, randomKeyGenerator);
+        base62Converter = Mockito.mock(Base62Converter.class);
+        randomKeyGenerator = Mockito.mock(RandomKeyGenerator.class);
+        urlShortenService = Mockito.mock(UrlShortenServiceImpl.class);
     }
 
     // Repository 에서 ShortUrl 을 찾지 못한 경우 NoSuchElementException 이 발생하는지 테스트
     @Test
     void testGetOriginalUrl_WhenShortUrlNotFound_ShouldThrowException() {
+        urlShortenService = new UrlShortenServiceImpl(urlShortenRepository, randomKeyGenerator);
+
         String shortUrl = "1234";
         Mockito.when(urlShortenRepository.findOriginUrlByKey(shortUrl)).thenReturn(Optional.empty());
 
@@ -47,6 +49,8 @@ class OnemBackendApplicationTests {
     // Repository 에서 ShortUrl 을 찾은 경우, 정상적으로 OriginalUrl 을 반환하는지 테스트
     @Test
     void testGetOriginalUrl_WhenShortUrlFound_ShouldReturnOriginalUrl() {
+        urlShortenService = new UrlShortenServiceImpl(urlShortenRepository, randomKeyGenerator);
+
         String shortUrl = "1234";
         String originalUrl = "http://www.google.com";
         Mockito.when(urlShortenRepository.findOriginUrlByKey(shortUrl)).thenReturn(Optional.of(originalUrl));
@@ -77,6 +81,8 @@ class OnemBackendApplicationTests {
     // Base62Converter 를 이용한 encoding, decoding 테스트 (encoding 후 decoding 시 원래 값과 같아야 함)
     @Test
     void testBase62EncodingAndDecoding() {
+        base62Converter = new Base62Converter();
+
         long value = System.currentTimeMillis();
         long[] testValues = {value, value + 1, value + 10, value + 100, value + 1000, value + 10000, value + 100000, value + 1000000};
 
@@ -92,6 +98,9 @@ class OnemBackendApplicationTests {
     // 생성된 shortUrl 의 길이가 7자리인지
     @Test
     void testCreateShortUrl_always_7digit() {
+        randomKeyGenerator = new RandomKeyGeneratorImpl(new Base62Converter());
+        urlShortenService = new UrlShortenServiceImpl(urlShortenRepository, randomKeyGenerator);
+
         String[] originalUrls = {"https://www.google.com", "https://www.naver.com", "https://www.daum.net"};
 
         for (String originalUrl : originalUrls) {
@@ -103,6 +112,8 @@ class OnemBackendApplicationTests {
     // 생성된 shortUrl 이 8자리가 되는 시점 테스트
     @Test
     void testCreateShortUrl_8digit() {
+        base62Converter = new Base62Converter();
+
         long value = 3521614606208L; // Tue Aug 05 2081 10:16:46 GMT+0000
         String encoded = base62Converter.encode(value);
 


### PR DESCRIPTION
### 문제🥲
- 두 개의 브랜치를 병합 후 테스트가 실패하는 상황
- 하나의 덩어리로 작업하던 브랜치를 분리하는 과정에서 특정 커밋이 반영되지 않음

### 수정 내용🔧
- `@BeforeEach` 어노테이션이 적용된 함수를 통해 Mocking 된 객체(default) 가 전달되도록  수정
- 각 테스트 단계에서는 검증 대상이 되는 객체를 생성하여 사용하도록 수정