### PR TITLE
[STEP2-4] 특정 도메인 차단 기능 구현

### DIFF
--- a/src/main/java/community/whatever/onembackendjava/BlockDomainException.java
+++ b/src/main/java/community/whatever/onembackendjava/BlockDomainException.java
@@ -1,0 +1,7 @@
+package community.whatever.onembackendjava;
+
+public class BlockDomainException extends RuntimeException {
+    public BlockDomainException(final String message) {
+        super("this domain is blocked: " + message);
+    }
+}

--- a/src/main/java/community/whatever/onembackendjava/BlockDomainLoader.java
+++ b/src/main/java/community/whatever/onembackendjava/BlockDomainLoader.java
@@ -1,67 +1,7 @@
 package community.whatever.onembackendjava;
 
-import jakarta.annotation.PostConstruct;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-@Component
-public class BlockDomainLoader {
-
-    @Value("${file.hosts.name}")
-    private String hostsFileName;
-
-    @Value("${file.hosts.source-url}")
-    private String hostsFileSourceUrl;
-
-    private Path filePath;
-
-    private final String SPACE_REGEX = "\\s+";
-    private final String COMMENT_SYMBOL = "#";
-
-    public Set<String> load() {
-
-        if (!Files.exists(filePath)) {
-            return new HashSet<>();
-        }
-
-        try (BufferedReader reader = Files.newBufferedReader(filePath, StandardCharsets.UTF_8)) {
-            return reader.lines()
-                    .filter(line -> !line.isEmpty() && !line.startsWith(COMMENT_SYMBOL))
-                    .map(line -> line.trim().split(SPACE_REGEX)[1])
-                    .collect(Collectors.toCollection(HashSet::new));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @PostConstruct
-    private void init() throws IOException {
-        filePath = Path.of(System.getProperty("user.dir"), hostsFileName);
-
-        if (!Files.exists(filePath)) {
-            downloadFile();
-        }
-    }
-
-    private void downloadFile() throws IOException {
-        RestTemplate restTemplate = new RestTemplate();
-        String content = restTemplate.getForObject(hostsFileSourceUrl, String.class);
-
-        if (content == null || content.isEmpty()) {
-            return;
-        }
-
-        Files.writeString(filePath, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-    }
+public interface BlockDomainLoader {
+    Set<String> load();
 }

--- a/src/main/java/community/whatever/onembackendjava/BlockDomainLoader.java
+++ b/src/main/java/community/whatever/onembackendjava/BlockDomainLoader.java
@@ -1,0 +1,67 @@
+package community.whatever.onembackendjava;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class BlockDomainLoader {
+
+    @Value("${file.hosts.name}")
+    private String hostsFileName;
+
+    @Value("${file.hosts.source-url}")
+    private String hostsFileSourceUrl;
+
+    private Path filePath;
+
+    private final String SPACE_REGEX = "\\s+";
+    private final String COMMENT_SYMBOL = "#";
+
+    public Set<String> load() {
+
+        if (!Files.exists(filePath)) {
+            return new HashSet<>();
+        }
+
+        try (BufferedReader reader = Files.newBufferedReader(filePath, StandardCharsets.UTF_8)) {
+            return reader.lines()
+                    .filter(line -> !line.isEmpty() && !line.startsWith(COMMENT_SYMBOL))
+                    .map(line -> line.trim().split(SPACE_REGEX)[1])
+                    .collect(Collectors.toCollection(HashSet::new));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @PostConstruct
+    private void init() throws IOException {
+        filePath = Path.of(System.getProperty("user.dir"), hostsFileName);
+
+        if (!Files.exists(filePath)) {
+            downloadFile();
+        }
+    }
+
+    private void downloadFile() throws IOException {
+        RestTemplate restTemplate = new RestTemplate();
+        String content = restTemplate.getForObject(hostsFileSourceUrl, String.class);
+
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+
+        Files.writeString(filePath, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+}

--- a/src/main/java/community/whatever/onembackendjava/BlockDomainLoaderImpl.java
+++ b/src/main/java/community/whatever/onembackendjava/BlockDomainLoaderImpl.java
@@ -1,5 +1,6 @@
 package community.whatever.onembackendjava;
 
+import io.micrometer.common.util.StringUtils;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -18,11 +19,11 @@ import java.util.stream.Collectors;
 @Component
 public class BlockDomainLoaderImpl implements BlockDomainLoader {
 
-    @Value("${file.hosts.name}")
-    private String hostsFileName;
+    @Value("${block-domain.loader.file.name}")
+    private String fileName;
 
-    @Value("${file.hosts.source-url}")
-    private String hostsFileSourceUrl;
+    @Value("${block-domain.loader.source.url}")
+    private String sourceUrl;
 
     private Path filePath;
 
@@ -47,7 +48,7 @@ public class BlockDomainLoaderImpl implements BlockDomainLoader {
 
     @PostConstruct
     private void init() throws IOException {
-        filePath = Path.of(System.getProperty("user.dir"), hostsFileName);
+        filePath = Path.of(System.getProperty("user.dir"), fileName);
 
         if (!Files.exists(filePath)) {
             downloadFile();
@@ -56,9 +57,9 @@ public class BlockDomainLoaderImpl implements BlockDomainLoader {
 
     private void downloadFile() throws IOException {
         RestTemplate restTemplate = new RestTemplate();
-        String content = restTemplate.getForObject(hostsFileSourceUrl, String.class);
+        String content = restTemplate.getForObject(sourceUrl, String.class);
 
-        if (content == null || content.isEmpty()) {
+        if (StringUtils.isBlank(content)) {
             return;
         }
 

--- a/src/main/java/community/whatever/onembackendjava/BlockDomainLoaderImpl.java
+++ b/src/main/java/community/whatever/onembackendjava/BlockDomainLoaderImpl.java
@@ -1,0 +1,67 @@
+package community.whatever.onembackendjava;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class BlockDomainLoaderImpl implements BlockDomainLoader {
+
+    @Value("${file.hosts.name}")
+    private String hostsFileName;
+
+    @Value("${file.hosts.source-url}")
+    private String hostsFileSourceUrl;
+
+    private Path filePath;
+
+    private final String SPACE_REGEX = "\\s+";
+    private final String COMMENT_SYMBOL = "#";
+
+    public Set<String> load() {
+
+        if (!Files.exists(filePath)) {
+            return new HashSet<>();
+        }
+
+        try (BufferedReader reader = Files.newBufferedReader(filePath, StandardCharsets.UTF_8)) {
+            return reader.lines()
+                    .filter(line -> !line.isEmpty() && !line.startsWith(COMMENT_SYMBOL))
+                    .map(line -> line.trim().split(SPACE_REGEX)[1])
+                    .collect(Collectors.toCollection(HashSet::new));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @PostConstruct
+    private void init() throws IOException {
+        filePath = Path.of(System.getProperty("user.dir"), hostsFileName);
+
+        if (!Files.exists(filePath)) {
+            downloadFile();
+        }
+    }
+
+    private void downloadFile() throws IOException {
+        RestTemplate restTemplate = new RestTemplate();
+        String content = restTemplate.getForObject(hostsFileSourceUrl, String.class);
+
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+
+        Files.writeString(filePath, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+}

--- a/src/main/java/community/whatever/onembackendjava/BlockDomainProvider.java
+++ b/src/main/java/community/whatever/onembackendjava/BlockDomainProvider.java
@@ -1,5 +1,6 @@
 package community.whatever.onembackendjava;
 
+import io.micrometer.common.util.StringUtils;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -15,27 +16,18 @@ public class BlockDomainProvider {
     }
 
     public boolean isBlocked(final String authority) {
-        if (authority == null || authority.isBlank()) {
-            return true;
-        }
-
-        return this.domains.contains(authority);
+        return StringUtils.isBlank(authority)
+        || this.domains.contains(authority);
     }
 
     public boolean isBlocked(final URI uri) {
-        if (uri == null || uri.getAuthority().isBlank()) {
-            return true;
-        }
-
-        return this.domains.contains(uri.getAuthority());
+        return StringUtils.isBlank(uri.getAuthority())
+        || this.domains.contains(uri.getAuthority());
     }
 
     public boolean isBlocked(final URL url) {
-        if (url == null || url.getAuthority().isBlank()) {
-            return true;
-        }
-
-        return this.domains.contains(url.getAuthority());
+        return StringUtils.isBlank(url.getAuthority())
+        || this.domains.contains(url.getAuthority());
     }
 
 }

--- a/src/main/java/community/whatever/onembackendjava/BlockDomainProvider.java
+++ b/src/main/java/community/whatever/onembackendjava/BlockDomainProvider.java
@@ -7,10 +7,10 @@ import java.net.URL;
 import java.util.Set;
 
 @Component
-public class BlockDomains {
+public class BlockDomainProvider {
     private final Set<String> domains;
 
-    public BlockDomains(final BlockDomainLoader blockDomainLoader) {
+    public BlockDomainProvider(final BlockDomainLoader blockDomainLoader) {
         this.domains = blockDomainLoader.load();
     }
 

--- a/src/main/java/community/whatever/onembackendjava/BlockDomains.java
+++ b/src/main/java/community/whatever/onembackendjava/BlockDomains.java
@@ -1,0 +1,41 @@
+package community.whatever.onembackendjava;
+
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.Set;
+
+@Component
+public class BlockDomains {
+    private final Set<String> domains;
+
+    public BlockDomains(final BlockDomainLoader blockDomainLoader) {
+        this.domains = blockDomainLoader.load();
+    }
+
+    public boolean isBlocked(final String authority) {
+        if (authority == null || authority.isBlank()) {
+            return true;
+        }
+
+        return this.domains.contains(authority);
+    }
+
+    public boolean isBlocked(final URI uri) {
+        if (uri == null || uri.getAuthority().isBlank()) {
+            return true;
+        }
+
+        return this.domains.contains(uri.getAuthority());
+    }
+
+    public boolean isBlocked(final URL url) {
+        if (url == null || url.getAuthority().isBlank()) {
+            return true;
+        }
+
+        return this.domains.contains(url.getAuthority());
+    }
+
+}

--- a/src/main/java/community/whatever/onembackendjava/ExpectedExceptionHandler.java
+++ b/src/main/java/community/whatever/onembackendjava/ExpectedExceptionHandler.java
@@ -28,6 +28,13 @@ public class ExpectedExceptionHandler {
         return e.getMessage();
     }
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(exception = BlockDomainException.class)
+    public String handleBlockDomainException(final BlockDomainException e) {
+        loggingError(e);
+        return e.getMessage();
+    }
+
     private void loggingError(final Exception e) {
         logger.error("Expected exception class: {}, message: {}", e.getClass().getName(), e.getMessage());
     }

--- a/src/main/java/community/whatever/onembackendjava/application/UrlShortenServiceImpl.java
+++ b/src/main/java/community/whatever/onembackendjava/application/UrlShortenServiceImpl.java
@@ -1,7 +1,7 @@
 package community.whatever.onembackendjava.application;
 
 import community.whatever.onembackendjava.BlockDomainException;
-import community.whatever.onembackendjava.BlockDomains;
+import community.whatever.onembackendjava.BlockDomainProvider;
 import community.whatever.onembackendjava.CustomDuplicateKeyException;
 import community.whatever.onembackendjava.repository.UrlShortenRepository;
 import org.springframework.stereotype.Service;
@@ -13,16 +13,16 @@ public class UrlShortenServiceImpl implements UrlShortenService {
 
     private final UrlShortenRepository urlShortenRepository;
     private final RandomKeyGenerator randomKeyGenerator;
-    private final BlockDomains blockDomains;
+    private final BlockDomainProvider blockDomainProvider;
 
     public UrlShortenServiceImpl(
             final UrlShortenRepository urlShortenRepository,
             final RandomKeyGenerator randomKeyGenerator,
-            final BlockDomains blockDomains
+            final BlockDomainProvider blockDomainProvider
     ) {
         this.urlShortenRepository = urlShortenRepository;
         this.randomKeyGenerator = randomKeyGenerator;
-        this.blockDomains = blockDomains;
+        this.blockDomainProvider = blockDomainProvider;
     }
 
     @Override
@@ -33,7 +33,7 @@ public class UrlShortenServiceImpl implements UrlShortenService {
 
     @Override
     public String createShortUrl(final String originUrl) throws CustomDuplicateKeyException {
-        if (blockDomains.isBlocked(URI.create(originUrl))) {
+        if (blockDomainProvider.isBlocked(URI.create(originUrl))) {
             throw new BlockDomainException(originUrl);
         }
 

--- a/src/main/java/community/whatever/onembackendjava/application/UrlShortenServiceImpl.java
+++ b/src/main/java/community/whatever/onembackendjava/application/UrlShortenServiceImpl.java
@@ -1,21 +1,28 @@
 package community.whatever.onembackendjava.application;
 
+import community.whatever.onembackendjava.BlockDomainException;
+import community.whatever.onembackendjava.BlockDomains;
 import community.whatever.onembackendjava.CustomDuplicateKeyException;
 import community.whatever.onembackendjava.repository.UrlShortenRepository;
 import org.springframework.stereotype.Service;
+
+import java.net.URI;
 
 @Service
 public class UrlShortenServiceImpl implements UrlShortenService {
 
     private final UrlShortenRepository urlShortenRepository;
     private final RandomKeyGenerator randomKeyGenerator;
+    private final BlockDomains blockDomains;
 
     public UrlShortenServiceImpl(
             final UrlShortenRepository urlShortenRepository,
-            final RandomKeyGenerator randomKeyGenerator
+            final RandomKeyGenerator randomKeyGenerator,
+            final BlockDomains blockDomains
     ) {
         this.urlShortenRepository = urlShortenRepository;
         this.randomKeyGenerator = randomKeyGenerator;
+        this.blockDomains = blockDomains;
     }
 
     @Override
@@ -26,6 +33,10 @@ public class UrlShortenServiceImpl implements UrlShortenService {
 
     @Override
     public String createShortUrl(final String originUrl) throws CustomDuplicateKeyException {
+        if (blockDomains.isBlocked(URI.create(originUrl))) {
+            throw new BlockDomainException(originUrl);
+        }
+
         String randomKey = randomKeyGenerator.getRandomKey();
 
         if (urlShortenRepository.existsByKey(randomKey)) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,8 @@
-spring.application.name=onem-backend
+spring:
+  application:
+    name: onem-backend
+
+file:
+  hosts:
+    name: hosts.txt
+    source-url: https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-porn/hosts

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,9 @@ spring:
   application:
     name: onem-backend
 
-file:
-  hosts:
-    name: hosts.txt
-    source-url: https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-porn/hosts
+block-domain:
+  loader:
+    file:
+      name: hosts.txt
+    source:
+      url: https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-porn/hosts

--- a/src/test/java/community/whatever/onembackendjava/BlockDomainLoaderTests.java
+++ b/src/test/java/community/whatever/onembackendjava/BlockDomainLoaderTests.java
@@ -1,0 +1,42 @@
+package community.whatever.onembackendjava;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class BlockDomainLoaderTests {
+
+    @Autowired
+    private BlockDomainLoader blockDomainLoader;
+    @Autowired
+    private BlockDomains blockDomains;
+
+    @Test
+    void testBlockDomainLoader() {
+        assertNotNull(blockDomainLoader.load());
+        assertInstanceOf(Collection.class, blockDomainLoader.load());
+    }
+
+    @Test
+    void testDomainBlock() throws URISyntaxException, MalformedURLException {
+        String localhost = "http://localhost";
+        URL url = new URL(localhost);
+        URI uri = new URI(localhost);
+
+        assertTrue(blockDomains.isBlocked(url));
+        assertTrue(blockDomains.isBlocked(uri));
+        assertTrue(blockDomains.isBlocked(url.getAuthority()));
+        assertTrue(blockDomains.isBlocked(uri.getAuthority()));
+        assertTrue(blockDomains.isBlocked(uri.getRawAuthority()));
+    }
+
+}

--- a/src/test/java/community/whatever/onembackendjava/BlockDomainLoaderTests.java
+++ b/src/test/java/community/whatever/onembackendjava/BlockDomainLoaderTests.java
@@ -18,7 +18,7 @@ class BlockDomainLoaderTests {
     @Autowired
     private BlockDomainLoader blockDomainLoader;
     @Autowired
-    private BlockDomains blockDomains;
+    private BlockDomainProvider blockDomainProvider;
 
     @Test
     void testBlockDomainLoader() {
@@ -32,11 +32,11 @@ class BlockDomainLoaderTests {
         URL url = new URL(localhost);
         URI uri = new URI(localhost);
 
-        assertTrue(blockDomains.isBlocked(url));
-        assertTrue(blockDomains.isBlocked(uri));
-        assertTrue(blockDomains.isBlocked(url.getAuthority()));
-        assertTrue(blockDomains.isBlocked(uri.getAuthority()));
-        assertTrue(blockDomains.isBlocked(uri.getRawAuthority()));
+        assertTrue(blockDomainProvider.isBlocked(url));
+        assertTrue(blockDomainProvider.isBlocked(uri));
+        assertTrue(blockDomainProvider.isBlocked(url.getAuthority()));
+        assertTrue(blockDomainProvider.isBlocked(uri.getAuthority()));
+        assertTrue(blockDomainProvider.isBlocked(uri.getRawAuthority()));
     }
 
 }

--- a/src/test/java/community/whatever/onembackendjava/OnemBackendApplicationTests.java
+++ b/src/test/java/community/whatever/onembackendjava/OnemBackendApplicationTests.java
@@ -5,7 +5,9 @@ import community.whatever.onembackendjava.application.RandomKeyGenerator;
 import community.whatever.onembackendjava.application.RandomKeyGeneratorImpl;
 import community.whatever.onembackendjava.application.UrlShortenServiceImpl;
 import community.whatever.onembackendjava.repository.UrlShortenRepository;
+import io.micrometer.common.util.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -142,6 +144,13 @@ class OnemBackendApplicationTests {
         System.out.printf("original: %d, encoded: %s, length: %d%n", value, encoded8digit, encoded8digit.length());
         assertEquals(7, encoded7digit.length());
         assertEquals(8, encoded8digit.length());
+    }
+
+    @Test
+    void testStringUtils() {
+        assertTrue(StringUtils.isBlank(null));
+        assertTrue(StringUtils.isBlank(""));
+        assertTrue(StringUtils.isBlank("     "));
     }
 
 }


### PR DESCRIPTION
## 개요📜
 [StevenBlack/hosts](https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-porn-social/hosts) 를 통해 제공되는 hosts.txt 파일을 이용하여 단축 url 생성 요청을 거절합니다.

## 구현 내용🧱
1. BlockDomainLoader
    - hosts.txt 파일의 위치는 project root 혹은 실행되는 jar 와 동일한 디렉토리입니다.
    - hosts.txt 파일이 존재하지 않는 경우 외부 저장소에 http 요청하며 응답 내용을 파일로 write 합니다.
    - hosts.txt 파일을 read 하여 이를 collection 형태로 반환합니다.
2. BlockDomains
    - BLockDomainLoader 를 통해 요청이 거절되어야 하는 도메인 정보를 전달 받습니다.
    - 도메인 정보를 통해 거절 대상을 검증합니다.

## 개선 필요📌
- 패키지 구조에 대해 조정